### PR TITLE
Add type data for AutoCAD 2000 to 2018 (dwg)

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -113,4 +113,10 @@ var CollectionData = []Collection{
 	{Type: "system", Extension: "sys", Mime: "application/vnd.microsoft.portable-executable", Offset: 0, Signature: []string{"4D 5A 80 00", "4D 5A 90 00"}},
 	{Type: "system", Extension: "reg", Mime: "application/vnd.microsoft.portable-executable", Offset: 0, Signature: []string{"52 45 47 45 44 49 54", "57 69 6E 64 6F 77 73 20 52 65 67 69 73 74 72 79"}},
 	{Type: "database", Extension: "sqlite", Mime: "application/x-sqlite3", Offset: 0, Signature: []string{"53 51 4C 69 74 65 20 66 6F 72 6D 61 74 20 33 00"}},
+	{Type: "cad", Extension: "dwg", Mime: "aplication/acad (AutoCAD 2000)", Offset: 0, Signature: []string{"41 43 31 30 31 35"}}, // AC1015
+	{Type: "cad", Extension: "dwg", Mime: "aplication/acad (AutoCAD 2004)", Offset: 0, Signature: []string{"41 43 31 30 31 38"}}, // AC1018
+	{Type: "cad", Extension: "dwg", Mime: "aplication/acad (AutoCAD 2007)", Offset: 0, Signature: []string{"41 43 31 30 32 31"}}, // AC1021
+	{Type: "cad", Extension: "dwg", Mime: "aplication/acad (AutoCAD 2010)", Offset: 0, Signature: []string{"41 43 31 30 32 34"}}, // AC1024
+	{Type: "cad", Extension: "dwg", Mime: "aplication/acad (AutoCAD 2013)", Offset: 0, Signature: []string{"41 43 31 30 32 37"}}, // AC1032
+	{Type: "cad", Extension: "dwg", Mime: "aplication/acad (AutoCAD 2018)", Offset: 0, Signature: []string{"41 43 31 30 33 32"}}, // AC1032
 }


### PR DESCRIPTION
Add type data for AutoCAD 2000 to 2018. 
If there are no problem, would you merge this ?

The source of the information is below.

[How to find the format of a DWG or which version of AutoCAD was used to create/save a DWG | AutoCAD | Autodesk Knowledge Network](https://knowledge.autodesk.com/support/autocad/learn-explore/caas/sfdcarticles/sfdcarticles/How-to-find-which-version-of-AutoCAD-was-used-to-create-save-a-DWG.html)